### PR TITLE
docs: add DDD analysis (current-work) and researched roadmap (planned…

### DIFF
--- a/docs/current-work.md
+++ b/docs/current-work.md
@@ -1,0 +1,161 @@
+# TSQR Tool Library — Current Work (DDD Analysis)
+
+> **Purpose:** a snapshot of *what has been built so far* and how it is structured, so a
+> developer can orient quickly. Companion to [`planned-work.md`](./planned-work.md), which
+> proposes the path forward. Generated from a domain-driven analysis of the codebase on
+> branch `chore/analysis` (= latest `main`, the "opencode" refactor).
+
+## 1. What this is
+
+A **community tool library** ("library of things") management system: members register tools
+that other members can **borrow, reserve, return, and flag for repair**, with **identity-verified
+membership**, **reservation queues**, **late-return fines**, and **per-location tool scarcity**.
+The founding domain notes live in [`docs/tooldomain.txt`](./tooldomain.txt) and
+[`docs/usersbreakdown.txt`](./usersbreakdown.txt).
+
+The solution is **C# / .NET 9** built with **Domain-Driven Design + Clean Architecture** and
+**MediatR** (CQRS-style commands).
+
+## 2. Solution structure & maturity at a glance
+
+| Project | Role | Maturity |
+|---|---|---|
+| `TSQR.ToolLibrary.Domain` | Aggregates, value objects, domain events, domain services, repository interfaces | 🟢 **Mostly implemented** |
+| `TSQR.ToolLibrary.Common` | Base building blocks (`Entity<TId>`, `ValueObject`, `IAggregateRoot`) + validation extensions | 🟢 Implemented |
+| `TSQR.ToolLibrary.Application` | MediatR command handlers (use cases) | 🟡 **Partial** — commands only, no queries, events not dispatched |
+| `TSQR.ToolLibrary.WebApi` | HTTP entry point | 🔴 **Stub** — default template (`WeatherForecast`), not wired to Application |
+| `TSQR.ToolLibrary.Infrastructure` | Persistence / external adapters | 🔴 **Missing** — empty folder, not in the solution |
+| `tests/.../Domain.UnitTests` | Unit tests | 🔴 **Removed** — directory exists, no source files |
+
+**Dependency direction (Clean Architecture, correct):**
+`WebApi → Application → Domain ← Common`. The Domain depends only on Common; there is no
+outward dependency from Domain to Application/Infrastructure.
+
+## 3. Ubiquitous language (current glossary)
+
+| Term | Meaning in the model |
+|---|---|
+| **Tool** | A *catalog definition* of a tool (model, manufacturer, type, amortization rate, per-location scarcity). |
+| **InventoryItem** | A *physical copy* of a Tool that actually circulates (has serial number, status, condition, holder). |
+| **Member** | A person in the library; may be Regular, Repairman, LocationCoordinator, or Admin; must be verified to borrow. |
+| **Loan** | A borrowing record binding a Member to an InventoryItem with checkout/due dates and accrued fine. |
+| **Reservation** | A request to pick up an item on a future date; carries a queue position and pickup confirmation. |
+| **MaintenanceRecord** | A repair ticket for an InventoryItem (Reported → InProgress → Completed). |
+| **Policy** | Tool-type + location lending rules (max loan days, max renewals, late fee/day, max reservation days). |
+| **Location / Country** | Where items live; basis for per-location scarcity and policy. |
+| **ScarcityLevel / AmortizationRate / Condition** | Tracked attributes that classify availability, wear, and state. |
+
+> **Note:** the codebase splits **Tool** (catalog) from **InventoryItem** (copy) — a good
+> instinct that matches industry practice (see `planned-work.md` §"Record vs. Copy").
+
+## 4. Domain model
+
+### 4.1 Aggregates
+
+Seven aggregate folders under `src/TSQR.ToolLibrary.Domain/Aggregates/`. Each root is
+`Entity<TId>, IAggregateRoot`; IDs are value objects wrapping an `int`.
+
+| Aggregate (root) | Key state | Behaviors | Domain events raised | Status |
+|---|---|---|---|---|
+| **Tool** | Model, Description, Manufacturer, Type, AmortizationRate, `ScarcityByLocation` | `Create`, `UpdateToolDetails`, `SetScarcityLevel`, `RemoveScarcityLevel` | — (registration event raised by Application) | 🟢 |
+| **InventoryItem** | ToolId, OwnerId, SerialNumber, `Status`, `Condition`, holder, loan count, usage time, repair flag | `Loan`, `Return`, `Reserve` (≤28d), `ClearReservation`, `MarkAsLost`, `MarkForRepair`, `CompleteRepair` | `ItemLoanedDomainEvent`, `ToolReturnedEvent` | 🟢 |
+| **Loan** | MemberId, ItemId, CheckoutDate, DueDate, `Status`, ReturnedDate, `FineAccrued` | `Create`, `EndLoan` (computes overdue + fine) | `LoanOverdueDomainEvent` | 🟡 fine hard-coded; no renewal |
+| **Reservation** | ItemId, MemberId, ReservationDate, ExpiryDate, `Status`, IsConfirmed, `QueuePosition` | `Create`, `ConfirmPickup`, `Activate`, `Cancel`, `Complete`, `MoveDownInQueue` | `ReservationConfirmedEvent`, `ReservationCancelledEvent` | 🟡 queue not automated |
+| **Member** | Name, contact, `Status`, `IsVerified`, verifier/date, `Record` | `Create`, `Verify`, `Suspend`, `Ban`, `Reinstate`, `IsEligibleToBorrow` | `MemberVerifiedEvent` | 🟢 |
+| **MaintenanceRecord** | ItemId, ReportedBy/Date, Description, `Status`, CompletedBy/Date, ResultingCondition | `Create`, `StartWork`, `Complete` | `ToolRepairedEvent` | 🟢 |
+| **Policy** *(+ Location, Country, Manufacturer as supporting entities)* | ToolType, LocationId, late fee/day, max loan/renewal/reservation days | `Create`, `SetDetails` | — | 🟡 defined, not enforced anywhere |
+
+Invariants are enforced in factories/methods via the validation extensions in Common
+(e.g. non-empty strings, defined/non-default enums, dates not in past/future, positive ints).
+
+### 4.2 Value objects, enums & state machines
+
+- **Value objects:** all aggregate IDs (`ToolId`, `MemberId`, `InventoryItemId`, `LoanId`,
+  `ReservationId`, `LocationId`, `CountryId`, `MaintenanceRecordId`, `PolicyId`,
+  `ManufacturerId`) plus `Address`. They derive from a `ValueObject` base providing
+  component-based equality. (Prevents primitive-obsession — good.)
+- **Enums / state machines** (all use `NotSet = 0` as an invalid default, validated on use):
+  - `ItemStatus`: Available → Reserved → Loaned → UnderMaintenance → Lost
+  - `LoanStatus`: NotSet → Active → Returned / Overdue / Canceled
+  - `ReservationStatus`: Pending → Confirmed → Active → Completed / Cancelled
+  - `MaintenanceStatus`: Reported → InProgress → Completed
+  - `MemberStatus`: Active / Suspended / Banned · `MembershipType`: Regular / Repairman / LocationCoordinator / Admin
+  - `Condition`: New / Good / Fair / Repaired / Poor · `ScarcityLevel`: Low / Medium / High / Critical · `AmortizationRate`: Low / Medium / High · `ToolType`: Hand/Power/Gardening/Construction/Specialty/Other
+
+### 4.3 Domain events
+
+`IDomainEvent : INotification` (MediatR). 14 event records in `Domain/Events/`:
+
+- **Raised today:** `ToolRegisteredEvent`, `ItemLoanedDomainEvent`, `ToolReturnedEvent`,
+  `ReservationConfirmedEvent`, `ReservationCancelledEvent`, `ToolMarkedForRepairEvent`,
+  `ToolRepairedEvent`, `LoanOverdueDomainEvent`, `MemberVerifiedEvent`, `ToolReservedEvent`.
+- **Defined but never raised (stubs):** `PickupReminderEvent`, `ReturnReminderEvent`,
+  `NextInLineNotificationEvent` — the notification side of the domain is not yet wired.
+
+> ⚠️ Events are **added to aggregates but never published** — there is no dispatcher in the
+> Application/WebApi layer, so no handler ever runs (see §7).
+
+### 4.4 Domain services
+
+- **`FineService`** — overdue-fine calculation (days overdue × fee). Implemented, but the
+  Application layer doesn't call it; `Loan.EndLoan` hard-codes `$1.00/day` instead.
+- **`MemberVerificationService`** — eligibility + admin-can-verify checks (used by `VerifyMemberCommand`).
+- **`ReservationQueueService`** — next-position, next-in-line, shift-after-cancel logic.
+  Implemented but **not integrated** with the reservation commands.
+
+### 4.5 Repository abstractions
+
+`IRepository<TAggregateRoot, TId>` (GetById/Add/Update/Delete + `IUnitOfWork`) and
+`IUnitOfWork` (SaveChangesAsync) are defined in the Domain. **No implementations exist** —
+the Infrastructure project is empty.
+
+## 5. Application layer (use cases)
+
+MediatR command handlers, organized by sub-area. **8 commands, 0 queries:**
+
+| Area | Commands |
+|---|---|
+| Tool | `RegisterToolCommand` |
+| Reservation | `ReserveToolCommand` (enforces ≤28-day advance), `ConfirmPickupCommand`, `CancelReservationCommand` |
+| Inventory | `ReturnToolCommand`, `MarkToolForRepairCommand`, `CompleteRepairCommand` |
+| Member | `VerifyMemberCommand` |
+
+Handlers load aggregates via `IRepository<T>` and call `UnitOfWork.SaveChangesAsync()`.
+**Gaps:** no read/query side; queue automation (`MoveDownInQueue`/`ShiftQueueAfterCancellation`)
+not invoked; domain events not dispatched.
+
+## 6. WebApi, Infrastructure, Tests
+
+- **WebApi:** `Program.cs` is the default .NET template (OpenAPI + sample `WeatherForecast`).
+  No MediatR registration, no DI for repositories, no DbContext, **no real endpoints**.
+- **Infrastructure:** placeholder folder, **0 source files, not referenced by the solution** —
+  no EF Core, no repository implementations, no persistence at all.
+- **Tests:** `tests/unit-tests/TSQR.ToolLibrary.Domain.UnitTests/` exists but contains only
+  build artifacts; the test sources were removed when `main` was aligned to the opencode refactor.
+
+## 7. Known issues / gaps observed (verify before relying on)
+
+These came out of the analysis and are worth confirming in code:
+
+1. **No persistence** — `IRepository`/`IUnitOfWork` have no implementations; nothing is stored.
+2. **No API** — WebApi is a template shell, not connected to the Application layer.
+3. **Domain events never published** — added to aggregates, but no dispatcher; the three reminder/
+   next-in-line events are never even raised.
+4. **Reservation queue not automated** — `ReservationQueueService` and `MoveDownInQueue` exist but
+   cancellation/return don't shift the queue or notify the next member.
+5. **Fines not policy-driven** — `Loan.EndLoan` hard-codes `$1.00/day`; `Policy.LateFeePerDay`
+   and `FineService` are unused.
+6. **No loan renewal** — `Policy.MaxRenewalCount` exists but `Loan` has no `Renew()`.
+7. **Policies unenforced** — `Policy` (max loan/reservation days) isn't consulted by any handler.
+8. **No tests** — unit tests were removed; there is currently no safety net.
+9. **Minor naming bugs** — `ManufcaturerId` (typo), `MaxLoanRerservationDays` (typo); a possible
+   `null` `CurrentHolderId` path around `ToolReturnedEvent` — confirm in code.
+
+## 8. Bottom line for a developer
+
+The **domain model is the mature part** and a solid foundation: aggregates, value objects,
+events, and a clean dependency structure are in place, and the ubiquitous language matches the
+problem space. What's missing is everything that makes it *run*: **persistence (Infrastructure),
+a real API (WebApi), event dispatching, queue/notification automation, policy enforcement, and
+tests**. The recommended sequence for closing those gaps — informed by how real tool libraries
+and existing platforms work — is in [`planned-work.md`](./planned-work.md).

--- a/docs/planned-work.md
+++ b/docs/planned-work.md
@@ -1,0 +1,121 @@
+# TSQR Tool Library — Planned Work (Roadmap & Suggestions)
+
+> **Purpose:** a researched path forward. Read [`current-work.md`](./current-work.md) first for
+> what exists today. This document maps the existing model against how real community tool
+> libraries and the established platforms work, then proposes a **prioritized roadmap** a solo
+> developer can follow. Suggestions are grounded in prior art (sources at the end).
+
+## 1. How the domain works in the real world (brief)
+
+Community tool libraries / "libraries of things" are **membership-based lending** (mostly free
+to borrow), not paid rental. The operational spine, consistent across operators and platforms:
+
+- **Membership** gated on eligibility (residency/age) with **document-backed identity verification**
+  and a signed **borrower agreement / liability waiver**; accounts with unpaid fees are **blocked**.
+- **Catalog** of items with **barcodes**, grouped by **item type/category** that *governs how they
+  circulate* (loan period, limits, fees).
+- **Lending**: short loan periods (commonly **7 days** for tools), **renewals** unless a hold exists,
+  **per-member item limits**.
+- **Reservations/holds** join a **queue** against an item, with a **pickup window**, **freeze/suspend**,
+  and **next-in-line** promotion; date-specific **bookings** for high-demand equipment.
+- **Returns** check condition; damaged items route to **repair/maintenance**.
+- **Overdue** handling is often **fine-free or low-fine** and trust-based, with an **escalation ladder**
+  (reminder → 30-day → 60-day → collections) and **replacement-cost** billing for lost/damaged items.
+- **Notifications** (hold-ready, due-soon, overdue, next-in-line) are the operational backbone.
+
+**Prior art to borrow from:**
+- **Koha** (open-source ILS) — the canonical **circulation domain model**: the **record↔copy split**,
+  **item types**, and **circulation rules** keyed on *(branch, patron category, item type)*. Best
+  source for vocabulary and state machines.
+- **Lend Engine** — the closest functional blueprint for a library-of-things: member **account
+  balances/credit**, reservations, **repair/cleaning assignments**, Stripe payments, self-serve portal.
+- **myTurn** — dominant tool-library SaaS: check-in/out, barcode scanning, reservations, reminders,
+  multi-location with transfers, utilization analytics.
+- **Libib** — lightweight cataloging (circulation is paid).
+
+## 2. Where the current model already aligns (keep)
+
+The existing design is on the right track and should be preserved:
+
+- ✅ **Tool (catalog) vs. InventoryItem (copy)** split — matches Koha's record↔copy, the single most
+  important modeling decision. Keep and lean into it (holds queue against the Tool; loans bind to a copy).
+- ✅ **Aggregates, value-object IDs, domain events, Clean Architecture layering** — solid DDD foundation.
+- ✅ **Member verification, scarcity-per-location, maintenance tickets, reservation queue position** —
+  all map to real-world concepts.
+
+## 3. Gaps vs. real-world practice (what to add)
+
+| Domain area | Real-world expectation | In the code today | Action |
+|---|---|---|---|
+| **Circulation rules** | One policy object keyed on *(location, member category, tool type)* → loan period, limits, renewals, fine rate | `Policy` exists but unenforced; rules hard-coded | Make `Policy`/`CirculationRule` first-class and **consult it in handlers** |
+| **Renewals** | Renew unless a hold exists; capped count | `MaxRenewalCount` defined, no `Renew()` | Add `Loan.Renew()` honoring policy + holds |
+| **Per-member limits** | Max items out at once | not modeled | Enforce in checkout handler |
+| **Fines** | Policy-driven, often fine-free; replacement cost on loss/damage | hard-coded `$1/day`; `FineService` unused | Drive fines from `Policy`; wire `FineService`; add replacement-cost charge |
+| **Account ledger / blocking** | Balance/credit; block borrowing when fees owed | not modeled | Add a Member **account balance** + block check |
+| **Holds queue & pickup window** | Queue, Waiting state, pickup window, freeze, next-in-line | position tracked, **not automated**; reminder/next-in-line events never raised | Automate queue shift + raise/handle notification events |
+| **Notifications** | Hold-ready, due-soon, overdue, next-in-line; escalation ladder | events defined but **never published** | Add event dispatch + notification handlers |
+| **Transfers / In-Transit** | Items move between branches for pickup | single-location only | Add transfer/In-Transit state (later) |
+| **Identity/privacy** | Store verification *outcome*, not document images | verification flag only | Keep as-is; store consent record, minimize PII |
+
+## 4. Architectural must-dos (the system doesn't run yet)
+
+These block everything else and should come first (see `current-work.md` §7):
+
+1. **Infrastructure layer** — create the `TSQR.ToolLibrary.Infrastructure` project (add to the solution),
+   implement **EF Core** `DbContext`, `IRepository<,>`/`IUnitOfWork`, and value-object/enum mappings.
+2. **Wire the WebApi** — register MediatR + repositories in DI, replace the `WeatherForecast` template
+   with real endpoints (or Minimal API) calling the Application commands.
+3. **Domain-event dispatch** — publish aggregates' events after `SaveChangesAsync` (e.g. MediatR
+   `INotificationPublisher` over an interceptor/outbox), so handlers actually fire.
+4. **Tests** — reintroduce a test project with unit tests for aggregate invariants and handler tests;
+   this is the safety net for everything below.
+
+## 5. Prioritized roadmap (by bounded context)
+
+Grouped near-term → later. The guiding principle (from Koha): **get Catalog + Circulation-Rule
+engine + Loan lifecycle right first; most else hangs off them.**
+
+### Near-term — make it runnable & operable (MVP)
+1. **Foundations:** Infrastructure + EF Core persistence; WebApi wired to Application; event dispatch; test project. *(§4)*
+2. **Catalog/Inventory:** finish copy lifecycle + barcodes + categories; expose CRUD/query endpoints; add **read/query handlers** (none exist today).
+3. **Membership/Identity:** registration with eligibility check, member category, verification outcome + borrower-agreement consent, account-block flag.
+4. **Lending:** a **CirculationRule** engine keyed on *(location, member category, tool type)*; `CreateLoan`/checkout, checkin, **`Renew`**; per-member limit + block-on-unpaid-fees enforcement; loan lifecycle incl. Overdue.
+5. **Billing/Fines (thin):** Member **account ledger**; policy-driven overdue accrual; replacement-cost charge on lost/damaged; manual mark-paid.
+6. **Notifications (thin):** due-soon + overdue reminders via event handlers.
+
+### Mid-term — richer circulation
+7. **Reservations:** automate the **queue** (shift on cancel/return), **Waiting/pickup-window** state, **next-in-line** promotion + notification, and **freeze/suspend**; add date-specific **Booking** for high-demand items.
+8. **Repair/Maintenance:** auto-route returned-as-damaged items to a maintenance ticket; `NotForLoan`/reserved-maintenance state; repair cost tracking.
+9. **Payments (full):** Stripe for fines/deposits; donations posted to the same ledger.
+10. **Notifications (full):** hold-ready + next-in-line; escalation ladder (30/60-day) with optional collections; configurable templates; multi-channel.
+
+### Later — differentiation & scale
+11. **Reporting/Metrics:** utilization per item/category, active members & growth, on-time-return rate, underused-asset report; **impact dashboard** (CO₂/$ saved) for funders.
+12. **Trust/Reputation (differentiator):** reputation score from on-time-return / loss / damage history; trust-tiered limits for peer-to-peer lending — incumbents don't model this.
+13. **Self-serve & ecosystem:** member self-checkout/reservation portal; donation/acquisition wish-list; multi-location transfers; role-based admin permissions; import/export; multilingual/accessibility.
+
+## 6. Suggested immediate next steps (concrete, ordered)
+
+1. Add the **Infrastructure** project to the solution; implement EF Core `DbContext` + one repository
+   (start with `Tool`/`InventoryItem`) and `UnitOfWork`.
+2. Register MediatR + repositories in **WebApi** DI; add a real `POST /tools` endpoint backed by the
+   existing `RegisterToolCommand` — proves the stack end-to-end.
+3. Add **domain-event publishing** after save; implement a first handler (e.g. log `ToolRegisteredEvent`).
+4. Stand up the **test project**; cover `InventoryItem` and `Loan` invariants + the register-tool handler.
+5. Introduce the **CirculationRule** concept and refactor `Loan.EndLoan` to use `Policy`/`FineService`
+   instead of the hard-coded `$1/day`; add `Loan.Renew()`.
+6. Fix the small naming bugs (`ManufcaturerId`, `MaxLoanRerservationDays`) while touching those files.
+
+## 7. Sources
+
+- Koha circulation manual — https://koha-community.org/manual/23.11/en/html/circulation.html
+- Koha item types — https://bywatersolutions.com/education/item-types-in-koha
+- Lend Engine (Library of Things) — https://www.lend-engine.com/software-for-library-of-things
+- myTurn (lending libraries) — https://myturn.com/lending-libraries/
+- Berkeley Tool Lending Library (borrowing rules, renewals, fines, eligibility) — https://www.berkeleypubliclibrary.org/locations/tool-lending-library/borrowing-tools
+- Oakland Tool Lending Library (rules) — https://oaklandlibrary.org/otll/rules-and-regulations/
+- LA County Library — Tools (fine-free, library-card tie-in) — https://lacountylibrary.org/tools/
+- Holds / pickup window / freeze behavior — https://aclibrary.org/faq/holds/ , https://kcls.org/faq/holds/
+- USDN tool-lending toolkit (fines/escalation) — https://sustainableconsumption.usdn.org/initiatives-list/tool-lending-libraries
+- myTurn — starting a tool library (agreements, donations, roles) — https://myturn.com/resource/starting-a-tool-library/
+- Tool utilization / impact study — https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1125&context=envstudtheses


### PR DESCRIPTION
…-work)

- docs/current-work.md: domain-driven analysis of the existing codebase — ubiquitous language, aggregates/VOs/events/services inventory, layer maturity (Domain implemented; Application partial; WebApi stub; Infrastructure/tests missing), and the concrete gaps (no persistence, events not dispatched, queue/fines/policy not wired)
- docs/planned-work.md: prioritized roadmap grounded in tool-library prior art (Koha circulation model, Lend Engine, myTurn): architectural must-dos, a near/mid/later bounded-context plan, ordered next steps, and sources

Gives a developer both the existing path and the path forward.