### PR TITLE
feat: postgres switch, query repos, controllers, handlers

### DIFF
--- a/src/TSQR.ToolLibrary.Domain/IDashboardQueries.cs
+++ b/src/TSQR.ToolLibrary.Domain/IDashboardQueries.cs
@@ -1,0 +1,8 @@
+namespace TSQR.ToolLibrary.Domain;
+
+public record DashboardData(int TotalTools, int TotalMembers, int ActiveLoans, int UnderMaintenance, int PendingReservations);
+
+public interface IDashboardQueries
+{
+    Task<DashboardData> GetStatsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/TSQR.ToolLibrary.Domain/IManufacturerRepository.cs
+++ b/src/TSQR.ToolLibrary.Domain/IManufacturerRepository.cs
@@ -1,0 +1,8 @@
+using TSQR.ToolLibrary.Domain.Aggregates.ToolAggregate;
+
+namespace TSQR.ToolLibrary.Domain;
+
+public interface IManufacturerRepository
+{
+    Task<List<Manufacturer>> GetAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/TSQR.ToolLibrary.Domain/IToolRepository.cs
+++ b/src/TSQR.ToolLibrary.Domain/IToolRepository.cs
@@ -1,0 +1,27 @@
+using TSQR.ToolLibrary.Domain.Aggregates.ToolAggregate;
+
+namespace TSQR.ToolLibrary.Domain;
+
+public interface IToolRepository : IRepository<Tool, ToolId>
+{
+    Task<List<Tool>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<ToolStats> GetStatsAsync(CancellationToken cancellationToken = default);
+}
+
+public record ToolStats(List<(int Key, string Label, int Count)> ByType, List<(int Key, string Label, int Count)> ByScarcity)
+{
+    private static readonly Dictionary<int, string> TypeNames = new()
+    {
+        { 1, "Hand Tool" }, { 2, "Power Tool" }, { 3, "Gardening Tool" },
+        { 4, "Construction Tool" }, { 5, "Specialty Tool" }, { 6, "Other" }
+    };
+
+    private static readonly Dictionary<int, string> ScarcityNames = new()
+    {
+        { 1, "Low" }, { 2, "Medium" }, { 3, "High" }, { 4, "Critical" }
+    };
+
+    public static string GetTypeName(int key) => TypeNames.GetValueOrDefault(key, "Unknown");
+    public static string GetScarcityName(int key) => ScarcityNames.GetValueOrDefault(key, "Unknown");
+}

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/DapperConnection.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/DapperConnection.cs
@@ -4,10 +4,10 @@ namespace TSQR.ToolLibrary.Infrastructure.Dapper;
 
 internal sealed class DapperConnection : IDatabaseConnection
 {
-    private readonly SqlConnection _connection;
+    private readonly NpgsqlConnection _connection;
     private readonly IDbTransaction? _transaction;
 
-    public DapperConnection(SqlConnection connection, IDbTransaction? transaction)
+    public DapperConnection(NpgsqlConnection connection, IDbTransaction? transaction)
     {
         _connection = connection;
         _transaction = transaction;

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/DapperUnitOfWork.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/DapperUnitOfWork.cs
@@ -4,14 +4,14 @@ namespace TSQR.ToolLibrary.Infrastructure.Dapper;
 
 public sealed class DapperUnitOfWork : IDatabaseUnitOfWork, IDisposable
 {
-    private readonly SqlConnection _connection;
+    private readonly NpgsqlConnection _connection;
     private IDbTransaction? _transaction;
     private DapperConnection? _connectionAdapter;
     private bool _disposed;
 
     public DapperUnitOfWork(string connectionString)
     {
-        _connection = new SqlConnection(connectionString);
+        _connection = new NpgsqlConnection(connectionString);
     }
 
     public IDatabaseConnection Connection

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/InventoryItemMapping.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/InventoryItemMapping.cs
@@ -16,6 +16,37 @@ internal sealed record InventoryItemRow(
     long TotalUsageTimeTicks,
     bool IsUnderRepair);
 
+internal sealed record InventoryItemInsertDto(
+    int ToolId,
+    int OriginalOwnerId,
+    DateTime InitialAcquisitionDate,
+    string SerialNumber,
+    ItemStatus Status,
+    Condition Condition,
+    int? CurrentHolderId,
+    DateTime? LastBorrowedDate,
+    DateTime? ReservationDate,
+    int? ReservationMemberId,
+    int LoanCount,
+    long TotalUsageTimeTicks,
+    bool IsUnderRepair);
+
+internal sealed record InventoryItemUpdateDto(
+    int Id,
+    int ToolId,
+    int OriginalOwnerId,
+    DateTime InitialAcquisitionDate,
+    string SerialNumber,
+    ItemStatus Status,
+    Condition Condition,
+    int? CurrentHolderId,
+    DateTime? LastBorrowedDate,
+    DateTime? ReservationDate,
+    int? ReservationMemberId,
+    int LoanCount,
+    long TotalUsageTimeTicks,
+    bool IsUnderRepair);
+
 public sealed class InventoryItemMapping : IEntityMapping<InventoryItem>
 {
     public string TableName => "InventoryItems";
@@ -29,7 +60,7 @@ public sealed class InventoryItemMapping : IEntityMapping<InventoryItem>
                 @Status, @Condition, @CurrentHolderId, @LastBorrowedDate,
                 @ReservationDate, @ReservationMemberId, @LoanCount,
                 @TotalUsageTimeTicks, @IsUnderRepair);
-          SELECT CAST(SCOPE_IDENTITY() AS INT)";
+          RETURNING Id";
 
     public string UpdateSql =>
         @"UPDATE InventoryItems
@@ -75,38 +106,34 @@ public sealed class InventoryItemMapping : IEntityMapping<InventoryItem>
             row.IsUnderRepair);
     }
 
-    public object ToInsertParameters(InventoryItem entity) => new
-    {
-        ToolId = entity.ToolId.Value,
-        OriginalOwnerId = entity.OriginalOwnerId.Value,
+    public object ToInsertParameters(InventoryItem entity) => new InventoryItemInsertDto(
+        entity.ToolId.Value,
+        entity.OriginalOwnerId.Value,
         entity.InitialAcquisitionDate,
         entity.SerialNumber,
-        Status = entity.Status,
-        Condition = entity.Condition,
-        CurrentHolderId = entity.CurrentHolderId?.Value,
+        entity.Status,
+        entity.Condition,
+        entity.CurrentHolderId?.Value,
         entity.LastBorrowedDate,
         entity.ReservationDate,
-        ReservationMemberId = entity.ReservationMemberId?.Value,
+        entity.ReservationMemberId?.Value,
         entity.LoanCount,
-        TotalUsageTimeTicks = entity.TotalUsageTime.Ticks,
-        entity.IsUnderRepair
-    };
+        entity.TotalUsageTime.Ticks,
+        entity.IsUnderRepair);
 
-    public object ToUpdateParameters(InventoryItem entity) => new
-    {
-        Id = entity.Id.Value,
-        ToolId = entity.ToolId.Value,
-        OriginalOwnerId = entity.OriginalOwnerId.Value,
+    public object ToUpdateParameters(InventoryItem entity) => new InventoryItemUpdateDto(
+        entity.Id.Value,
+        entity.ToolId.Value,
+        entity.OriginalOwnerId.Value,
         entity.InitialAcquisitionDate,
         entity.SerialNumber,
-        Status = entity.Status,
-        Condition = entity.Condition,
-        CurrentHolderId = entity.CurrentHolderId?.Value,
+        entity.Status,
+        entity.Condition,
+        entity.CurrentHolderId?.Value,
         entity.LastBorrowedDate,
         entity.ReservationDate,
-        ReservationMemberId = entity.ReservationMemberId?.Value,
+        entity.ReservationMemberId?.Value,
         entity.LoanCount,
-        TotalUsageTimeTicks = entity.TotalUsageTime.Ticks,
-        entity.IsUnderRepair
-    };
+        entity.TotalUsageTime.Ticks,
+        entity.IsUnderRepair);
 }

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/MaintenanceRecordMapping.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/MaintenanceRecordMapping.cs
@@ -11,6 +11,27 @@ internal sealed record MaintenanceRecordRow(
     DateTime? CompletedDate,
     Condition? ResultingCondition);
 
+internal sealed record MaintenanceRecordInsertDto(
+    int ItemId,
+    int ReportedById,
+    DateTime ReportedDate,
+    string Description,
+    MaintenanceStatus Status,
+    int? CompletedById,
+    DateTime? CompletedDate,
+    Condition? ResultingCondition);
+
+internal sealed record MaintenanceRecordUpdateDto(
+    int Id,
+    int ItemId,
+    int ReportedById,
+    DateTime ReportedDate,
+    string Description,
+    MaintenanceStatus Status,
+    int? CompletedById,
+    DateTime? CompletedDate,
+    Condition? ResultingCondition);
+
 public sealed class MaintenanceRecordMapping : IEntityMapping<MaintenanceRecord>
 {
     public string TableName => "MaintenanceRecords";
@@ -20,7 +41,7 @@ public sealed class MaintenanceRecordMapping : IEntityMapping<MaintenanceRecord>
                 CompletedById, CompletedDate, ResultingCondition)
           VALUES (@ItemId, @ReportedById, @ReportedDate, @Description, @Status,
                 @CompletedById, @CompletedDate, @ResultingCondition);
-          SELECT CAST(SCOPE_IDENTITY() AS INT)";
+          RETURNING Id";
 
     public string UpdateSql =>
         @"UPDATE MaintenanceRecords
@@ -53,28 +74,24 @@ public sealed class MaintenanceRecordMapping : IEntityMapping<MaintenanceRecord>
             row.ResultingCondition);
     }
 
-    public object ToInsertParameters(MaintenanceRecord entity) => new
-    {
-        ItemId = entity.ItemId.Value,
-        ReportedById = entity.ReportedById.Value,
+    public object ToInsertParameters(MaintenanceRecord entity) => new MaintenanceRecordInsertDto(
+        entity.ItemId.Value,
+        entity.ReportedById.Value,
         entity.ReportedDate,
         entity.Description,
-        Status = entity.Status,
-        CompletedById = entity.CompletedById?.Value,
+        entity.Status,
+        entity.CompletedById?.Value,
         entity.CompletedDate,
-        ResultingCondition = entity.ResultingCondition
-    };
+        entity.ResultingCondition);
 
-    public object ToUpdateParameters(MaintenanceRecord entity) => new
-    {
-        Id = entity.Id.Value,
-        ItemId = entity.ItemId.Value,
-        ReportedById = entity.ReportedById.Value,
+    public object ToUpdateParameters(MaintenanceRecord entity) => new MaintenanceRecordUpdateDto(
+        entity.Id.Value,
+        entity.ItemId.Value,
+        entity.ReportedById.Value,
         entity.ReportedDate,
         entity.Description,
-        Status = entity.Status,
-        CompletedById = entity.CompletedById?.Value,
+        entity.Status,
+        entity.CompletedById?.Value,
         entity.CompletedDate,
-        ResultingCondition = entity.ResultingCondition
-    };
+        entity.ResultingCondition);
 }

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/MemberMapping.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/MemberMapping.cs
@@ -17,6 +17,39 @@ internal sealed record MemberRow(
     DateTime? StartDate,
     DateTime? EndDate);
 
+internal sealed record MemberInsertDto(
+    string FirstName,
+    string MiddleName,
+    string LastName,
+    int Age,
+    string Address,
+    string Email,
+    string PhoneNumber,
+    MemberStatus Status,
+    bool IsVerified,
+    int? VerifiedByAdminId,
+    DateTime? VerificationDate,
+    MembershipType? MembershipType,
+    DateTime? StartDate,
+    DateTime? EndDate);
+
+internal sealed record MemberUpdateDto(
+    int Id,
+    string FirstName,
+    string MiddleName,
+    string LastName,
+    int Age,
+    string Address,
+    string Email,
+    string PhoneNumber,
+    MemberStatus Status,
+    bool IsVerified,
+    int? VerifiedByAdminId,
+    DateTime? VerificationDate,
+    MembershipType? MembershipType,
+    DateTime? StartDate,
+    DateTime? EndDate);
+
 public sealed class MemberMapping : IEntityMapping<Member>
 {
     public string TableName => "Members";
@@ -28,7 +61,7 @@ public sealed class MemberMapping : IEntityMapping<Member>
           VALUES (@FirstName, @MiddleName, @LastName, @Age, @Address, @Email, @PhoneNumber,
                 @Status, @IsVerified, @VerifiedByAdminId, @VerificationDate,
                 @MembershipType, @StartDate, @EndDate);
-          SELECT CAST(SCOPE_IDENTITY() AS INT)";
+          RETURNING Id";
 
     public string UpdateSql =>
         @"UPDATE Members
@@ -71,8 +104,7 @@ public sealed class MemberMapping : IEntityMapping<Member>
             record);
     }
 
-    public object ToInsertParameters(Member entity) => new
-    {
+    public object ToInsertParameters(Member entity) => new MemberInsertDto(
         entity.FirstName,
         entity.MiddleName,
         entity.LastName,
@@ -80,18 +112,16 @@ public sealed class MemberMapping : IEntityMapping<Member>
         entity.Address,
         entity.Email,
         entity.PhoneNumber,
-        Status = entity.Status,
+        entity.Status,
         entity.IsVerified,
-        VerifiedByAdminId = entity.VerifiedByAdminId?.Value,
+        entity.VerifiedByAdminId?.Value,
         entity.VerificationDate,
-        MembershipType = entity.Record?.MembershipType,
-        StartDate = entity.Record?.StartDate,
-        EndDate = entity.Record?.EndDate
-    };
+        entity.Record?.MembershipType,
+        entity.Record?.StartDate,
+        entity.Record?.EndDate);
 
-    public object ToUpdateParameters(Member entity) => new
-    {
-        Id = entity.Id.Value,
+    public object ToUpdateParameters(Member entity) => new MemberUpdateDto(
+        entity.Id.Value,
         entity.FirstName,
         entity.MiddleName,
         entity.LastName,
@@ -99,12 +129,11 @@ public sealed class MemberMapping : IEntityMapping<Member>
         entity.Address,
         entity.Email,
         entity.PhoneNumber,
-        Status = entity.Status,
+        entity.Status,
         entity.IsVerified,
-        VerifiedByAdminId = entity.VerifiedByAdminId?.Value,
+        entity.VerifiedByAdminId?.Value,
         entity.VerificationDate,
-        MembershipType = entity.Record?.MembershipType,
-        StartDate = entity.Record?.StartDate,
-        EndDate = entity.Record?.EndDate
-    };
+        entity.Record?.MembershipType,
+        entity.Record?.StartDate,
+        entity.Record?.EndDate);
 }

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/ReservationMapping.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/ReservationMapping.cs
@@ -10,6 +10,25 @@ internal sealed record ReservationRow(
     bool IsConfirmed,
     int QueuePosition);
 
+internal sealed record ReservationInsertDto(
+    int ItemId,
+    int MemberId,
+    DateTime ReservationDate,
+    DateTime ExpiryDate,
+    ReservationStatus Status,
+    bool IsConfirmed,
+    int QueuePosition);
+
+internal sealed record ReservationUpdateDto(
+    int Id,
+    int ItemId,
+    int MemberId,
+    DateTime ReservationDate,
+    DateTime ExpiryDate,
+    ReservationStatus Status,
+    bool IsConfirmed,
+    int QueuePosition);
+
 public sealed class ReservationMapping : IEntityMapping<Reservation>
 {
     public string TableName => "Reservations";
@@ -17,7 +36,7 @@ public sealed class ReservationMapping : IEntityMapping<Reservation>
     public string InsertSql =>
         @"INSERT INTO Reservations (ItemId, MemberId, ReservationDate, ExpiryDate, Status, IsConfirmed, QueuePosition)
           VALUES (@ItemId, @MemberId, @ReservationDate, @ExpiryDate, @Status, @IsConfirmed, @QueuePosition);
-          SELECT CAST(SCOPE_IDENTITY() AS INT)";
+          RETURNING Id";
 
     public string UpdateSql =>
         @"UPDATE Reservations
@@ -49,26 +68,22 @@ public sealed class ReservationMapping : IEntityMapping<Reservation>
             row.QueuePosition);
     }
 
-    public object ToInsertParameters(Reservation entity) => new
-    {
-        ItemId = entity.ItemId.Value,
-        MemberId = entity.MemberId.Value,
+    public object ToInsertParameters(Reservation entity) => new ReservationInsertDto(
+        entity.ItemId.Value,
+        entity.MemberId.Value,
         entity.ReservationDate,
         entity.ExpiryDate,
-        Status = entity.Status,
+        entity.Status,
         entity.IsConfirmed,
-        entity.QueuePosition
-    };
+        entity.QueuePosition);
 
-    public object ToUpdateParameters(Reservation entity) => new
-    {
-        Id = entity.Id.Value,
-        ItemId = entity.ItemId.Value,
-        MemberId = entity.MemberId.Value,
+    public object ToUpdateParameters(Reservation entity) => new ReservationUpdateDto(
+        entity.Id.Value,
+        entity.ItemId.Value,
+        entity.MemberId.Value,
         entity.ReservationDate,
         entity.ExpiryDate,
-        Status = entity.Status,
+        entity.Status,
         entity.IsConfirmed,
-        entity.QueuePosition
-    };
+        entity.QueuePosition);
 }

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/ToolMapping.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Mappings/ToolMapping.cs
@@ -12,6 +12,23 @@ internal sealed record ToolRow(
 
 internal sealed record ScarcityRow(LocationId LocationId, ScarcityLevel ScarcityLevel);
 
+internal sealed record ToolInsertDto(
+    string Model,
+    string Description,
+    int ManufacturerId,
+    ToolType ToolType,
+    AmortizationRate AmortizationRate,
+    string? Metadata);
+
+internal sealed record ToolUpdateDto(
+    int Id,
+    string Model,
+    string Description,
+    int ManufacturerId,
+    ToolType ToolType,
+    AmortizationRate AmortizationRate,
+    string? Metadata);
+
 public sealed class ToolMapping : IEntityMapping<Tool>
 {
     public string TableName => "Tools";
@@ -19,7 +36,7 @@ public sealed class ToolMapping : IEntityMapping<Tool>
     public string InsertSql =>
         @"INSERT INTO Tools (Model, Description, ManufacturerId, ToolType, AmortizationRate, Metadata)
           VALUES (@Model, @Description, @ManufacturerId, @ToolType, @AmortizationRate, @Metadata);
-          SELECT CAST(SCOPE_IDENTITY() AS INT)";
+          RETURNING Id";
 
     public string UpdateSql =>
         @"UPDATE Tools
@@ -59,24 +76,20 @@ public sealed class ToolMapping : IEntityMapping<Tool>
         return tool;
     }
 
-    public object ToInsertParameters(Tool entity) => new
-    {
+    public object ToInsertParameters(Tool entity) => new ToolInsertDto(
         entity.Model,
         entity.Description,
-        ManufacturerId = entity.Manufacturer.Id.Value,
-        ToolType = entity.Type,
-        AmortizationRate = entity.AmortizationRate,
-        entity.Metadata
-    };
+        entity.Manufacturer.Id.Value,
+        entity.Type,
+        entity.AmortizationRate,
+        entity.Metadata);
 
-    public object ToUpdateParameters(Tool entity) => new
-    {
-        Id = entity.Id.Value,
+    public object ToUpdateParameters(Tool entity) => new ToolUpdateDto(
+        entity.Id.Value,
         entity.Model,
         entity.Description,
-        ManufacturerId = entity.Manufacturer.Id.Value,
-        ToolType = entity.Type,
-        AmortizationRate = entity.AmortizationRate,
-        entity.Metadata
-    };
+        entity.Manufacturer.Id.Value,
+        entity.Type,
+        entity.AmortizationRate,
+        entity.Metadata);
 }

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Repositories/DashboardQueries.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Repositories/DashboardQueries.cs
@@ -1,0 +1,29 @@
+using TSQR.ToolLibrary.Domain;
+
+namespace TSQR.ToolLibrary.Infrastructure.Dapper.Repositories;
+
+public sealed class DashboardQueries : IDashboardQueries
+{
+    private readonly IDatabaseUnitOfWork _uow;
+
+    public DashboardQueries(IDatabaseUnitOfWork uow)
+    {
+        _uow = uow;
+    }
+
+    public async Task<DashboardData> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        var db = _uow.Connection;
+
+        var totalTools = await db.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM Tools");
+        var totalMembers = await db.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM Members");
+        var activeLoans = await db.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM InventoryItems WHERE Status = 3");
+        var underMaintenance = await db.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM InventoryItems WHERE IsUnderRepair = TRUE");
+        var pendingReservations = await db.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM Reservations WHERE Status = 1");
+
+        return new DashboardData(totalTools, totalMembers, activeLoans, underMaintenance, pendingReservations);
+    }
+}

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Repositories/ManufacturerRepository.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Repositories/ManufacturerRepository.cs
@@ -1,0 +1,23 @@
+using TSQR.ToolLibrary.Domain;
+
+namespace TSQR.ToolLibrary.Infrastructure.Dapper.Repositories;
+
+public sealed class ManufacturerRepository : IManufacturerRepository
+{
+    private readonly IDatabaseUnitOfWork _uow;
+
+    public ManufacturerRepository(IDatabaseUnitOfWork uow)
+    {
+        _uow = uow;
+    }
+
+    public async Task<List<Manufacturer>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var rows = await _uow.Connection.QueryAsync<ManufacturerRow>(
+            "SELECT Id, Name FROM Manufacturers ORDER BY Name");
+
+        return rows.Select(r => Manufacturer.Create(new ManufcaturerId(r.Id), r.Name)).ToList();
+    }
+
+    private sealed record ManufacturerRow(int Id, string Name);
+}

--- a/src/TSQR.ToolLibrary.Infrastructure/Dapper/Repositories/ToolRepository.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/Dapper/Repositories/ToolRepository.cs
@@ -1,9 +1,43 @@
+using TSQR.ToolLibrary.Domain;
+
 namespace TSQR.ToolLibrary.Infrastructure.Dapper.Repositories;
 
-public sealed class ToolRepository : Repository<Tool, ToolId>
+public sealed class ToolRepository : Repository<Tool, ToolId>, IToolRepository
 {
     public ToolRepository(IDatabaseUnitOfWork uow, IEntityMapping<Tool> mapping) : base(uow, mapping)
     {
+    }
+
+    public async Task<List<Tool>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var rows = await Database.QueryAsync<ToolRow>(
+            @"SELECT t.Id, t.Model, t.Description, t.ToolType, t.AmortizationRate, t.Metadata,
+                     m.Id AS ManufacturerId, m.Name AS ManufacturerName
+              FROM Tools t
+              INNER JOIN Manufacturers m ON m.Id = t.ManufacturerId
+              ORDER BY t.Model");
+
+        return rows.Select(r => Tool.Create(
+            new ToolId(r.Id),
+            r.Model,
+            r.Description,
+            Manufacturer.Create(new ManufcaturerId(r.ManufacturerId), r.ManufacturerName),
+            (ToolType)r.ToolType,
+            (AmortizationRate)r.AmortizationRate,
+            r.Metadata)).ToList();
+    }
+
+    public async Task<ToolStats> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        var typeStats = await Database.QueryAsync<StatsRow>(
+            "SELECT ToolType AS Key, COUNT(*) AS Count FROM Tools GROUP BY ToolType ORDER BY Key");
+
+        var scarcityStats = await Database.QueryAsync<StatsRow>(
+            "SELECT sl.ScarcityLevel AS Key, COUNT(*) AS Count FROM ToolScarcityByLocation sl GROUP BY sl.ScarcityLevel ORDER BY Key");
+
+        return new ToolStats(
+            typeStats.Select(s => (s.Key, ToolStats.GetTypeName(s.Key), s.Count)).ToList(),
+            scarcityStats.Select(s => (s.Key, ToolStats.GetScarcityName(s.Key), s.Count)).ToList());
     }
 
     public override async Task AddAsync(Tool entity, CancellationToken cancellationToken = default)
@@ -40,4 +74,11 @@ public sealed class ToolRepository : Repository<Tool, ToolId>
 
         base.Delete(entity);
     }
+
+    private sealed record ToolRow(
+        int Id, string Model, string Description, int ToolType,
+        int AmortizationRate, string? Metadata,
+        int ManufacturerId, string ManufacturerName);
+
+    private sealed record StatsRow(int Key, int Count);
 }

--- a/src/TSQR.ToolLibrary.Infrastructure/GlobalUsings.cs
+++ b/src/TSQR.ToolLibrary.Infrastructure/GlobalUsings.cs
@@ -1,6 +1,6 @@
 global using System.Data;
 global using Dapper;
-global using Microsoft.Data.SqlClient;
+global using Npgsql;
 global using TSQR.ToolLibrary.Domain;
 global using TSQR.ToolLibrary.Infrastructure.Abstractions;
 global using TSQR.ToolLibrary.Domain.Aggregates.ToolAggregate;

--- a/src/TSQR.ToolLibrary.Infrastructure/TSQR.ToolLibrary.Infrastructure.csproj
+++ b/src/TSQR.ToolLibrary.Infrastructure/TSQR.ToolLibrary.Infrastructure.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TSQR.ToolLibrary.WebApi/Controllers/DashboardController.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Controllers/DashboardController.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+using TSQR.ToolLibrary.WebApi.Queries;
+
+namespace TSQR.ToolLibrary.WebApi.Controllers;
+
+[ApiController]
+[Route("api/dashboard")]
+public sealed class DashboardController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public DashboardController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("stats")]
+    public async Task<DashboardStats> GetStats()
+    {
+        return await _mediator.Send(new GetDashboardStatsQuery());
+    }
+}

--- a/src/TSQR.ToolLibrary.WebApi/Controllers/Dtos/DashboardDtos.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Controllers/Dtos/DashboardDtos.cs
@@ -1,0 +1,3 @@
+namespace TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+
+public record DashboardStats(int TotalTools, int TotalMembers, int ActiveLoans, int UnderMaintenance, int PendingReservations);

--- a/src/TSQR.ToolLibrary.WebApi/Controllers/Dtos/ToolDtos.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Controllers/Dtos/ToolDtos.cs
@@ -1,0 +1,33 @@
+namespace TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+
+public record ToolListItem(
+    int Id,
+    string Model,
+    string Description,
+    int ToolType,
+    string ToolTypeName,
+    int AmortizationRate,
+    string AmortizationRateName,
+    int ManufacturerId,
+    string ManufacturerName);
+
+public record ToolDetail(
+    int Id,
+    string Model,
+    string Description,
+    int ManufacturerId,
+    string ManufacturerName,
+    int ToolType,
+    string ToolTypeName,
+    int AmortizationRate,
+    string AmortizationRateName,
+    string? Metadata,
+    List<ScarcityDto> ScarcityByLocation);
+
+public record ScarcityDto(int LocationId, string LocationName, int ScarcityLevel, string ScarcityLevelName);
+
+public record ToolStatsItem(int Key, string Label, int Count);
+
+public record ManufacturerDto(int Id, string Name);
+
+public record PagedResult<T>(List<T> Items, int TotalCount, int Page, int PageSize);

--- a/src/TSQR.ToolLibrary.WebApi/Controllers/ManufacturersController.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Controllers/ManufacturersController.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+using TSQR.ToolLibrary.WebApi.Queries;
+
+namespace TSQR.ToolLibrary.WebApi.Controllers;
+
+[ApiController]
+[Route("api/manufacturers")]
+public sealed class ManufacturersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public ManufacturersController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<List<ManufacturerDto>> GetAll()
+    {
+        return await _mediator.Send(new GetManufacturersQuery());
+    }
+}

--- a/src/TSQR.ToolLibrary.WebApi/Controllers/ToolsController.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Controllers/ToolsController.cs
@@ -1,0 +1,43 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+using TSQR.ToolLibrary.WebApi.Queries;
+
+namespace TSQR.ToolLibrary.WebApi.Controllers;
+
+[ApiController]
+[Route("api/tools")]
+public sealed class ToolsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public ToolsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<PagedResult<ToolListItem>> GetTools(
+        [FromQuery] string? q,
+        [FromQuery] int? type,
+        [FromQuery] int? manufacturerId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20)
+    {
+        return await _mediator.Send(new GetToolsQuery(q, type, manufacturerId, page, pageSize));
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<ToolDetail>> GetTool(int id)
+    {
+        var result = await _mediator.Send(new GetToolByIdQuery(id));
+        if (result is null) return NotFound();
+        return result;
+    }
+
+    [HttpGet("stats")]
+    public async Task<ToolStatsResult> GetStats()
+    {
+        return await _mediator.Send(new GetToolStatsQuery());
+    }
+}

--- a/src/TSQR.ToolLibrary.WebApi/Program.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Program.cs
@@ -9,12 +9,14 @@ using TSQR.ToolLibrary.Infrastructure.Abstractions;
 using TSQR.ToolLibrary.Infrastructure.Dapper;
 using TSQR.ToolLibrary.Infrastructure.Dapper.Mappings;
 using TSQR.ToolLibrary.Infrastructure.Dapper.Repositories;
+using TSQR.ToolLibrary.WebApi.Queries;
 
 TypeHandlerRegistrations.EnsureRegistered();
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
+builder.Services.AddControllers();
 
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
     ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
@@ -22,7 +24,10 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 builder.Services.AddScoped<IDatabaseUnitOfWork>(_ => new DapperUnitOfWork(connectionString));
 
 builder.Services.AddMediatR(cfg =>
-    cfg.RegisterServicesFromAssembly(typeof(RegisterToolCommand).Assembly));
+{
+    cfg.RegisterServicesFromAssembly(typeof(RegisterToolCommand).Assembly);
+    cfg.RegisterServicesFromAssembly(typeof(GetToolsQuery).Assembly);
+});
 
 builder.Services.AddSingleton<IEntityMapping<InventoryItem>, InventoryItemMapping>();
 builder.Services.AddSingleton<IEntityMapping<Member>, MemberMapping>();
@@ -34,7 +39,9 @@ builder.Services.AddScoped<IRepository<InventoryItem, InventoryItemId>, Reposito
 builder.Services.AddScoped<IRepository<Member, MemberId>, Repository<Member, MemberId>>();
 builder.Services.AddScoped<IRepository<Reservation, ReservationId>, Repository<Reservation, ReservationId>>();
 builder.Services.AddScoped<IRepository<MaintenanceRecord, MaintenanceRecordId>, Repository<MaintenanceRecord, MaintenanceRecordId>>();
-builder.Services.AddScoped<IRepository<Tool, ToolId>, ToolRepository>();
+builder.Services.AddScoped<IToolRepository, ToolRepository>();
+builder.Services.AddScoped<IManufacturerRepository, ManufacturerRepository>();
+builder.Services.AddScoped<IDashboardQueries, DashboardQueries>();
 
 var app = builder.Build();
 
@@ -44,5 +51,5 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
+app.MapControllers();
 app.Run();

--- a/src/TSQR.ToolLibrary.WebApi/Queries/GetDashboardStatsQuery.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Queries/GetDashboardStatsQuery.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using TSQR.ToolLibrary.Domain;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+
+namespace TSQR.ToolLibrary.WebApi.Queries;
+
+public record GetDashboardStatsQuery : IRequest<DashboardStats>;
+
+public sealed class GetDashboardStatsHandler : IRequestHandler<GetDashboardStatsQuery, DashboardStats>
+{
+    private readonly IDashboardQueries _dashboardQueries;
+
+    public GetDashboardStatsHandler(IDashboardQueries dashboardQueries)
+    {
+        _dashboardQueries = dashboardQueries;
+    }
+
+    public async Task<DashboardStats> Handle(GetDashboardStatsQuery request, CancellationToken ct)
+    {
+        var data = await _dashboardQueries.GetStatsAsync(ct);
+        return new DashboardStats(data.TotalTools, data.TotalMembers, data.ActiveLoans, data.UnderMaintenance, data.PendingReservations);
+    }
+}

--- a/src/TSQR.ToolLibrary.WebApi/Queries/GetManufacturersQuery.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Queries/GetManufacturersQuery.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using TSQR.ToolLibrary.Domain;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+
+namespace TSQR.ToolLibrary.WebApi.Queries;
+
+public record GetManufacturersQuery : IRequest<List<ManufacturerDto>>;
+
+public sealed class GetManufacturersHandler : IRequestHandler<GetManufacturersQuery, List<ManufacturerDto>>
+{
+    private readonly IManufacturerRepository _manufacturerRepo;
+
+    public GetManufacturersHandler(IManufacturerRepository manufacturerRepo)
+    {
+        _manufacturerRepo = manufacturerRepo;
+    }
+
+    public async Task<List<ManufacturerDto>> Handle(GetManufacturersQuery request, CancellationToken ct)
+    {
+        var manufacturers = await _manufacturerRepo.GetAllAsync(ct);
+        return manufacturers.Select(m => new ManufacturerDto(m.Id.Value, m.Name)).ToList();
+    }
+}

--- a/src/TSQR.ToolLibrary.WebApi/Queries/GetToolByIdQuery.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Queries/GetToolByIdQuery.cs
@@ -1,0 +1,63 @@
+using MediatR;
+using TSQR.ToolLibrary.Domain;
+using TSQR.ToolLibrary.Domain.Aggregates.ToolAggregate;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+
+namespace TSQR.ToolLibrary.WebApi.Queries;
+
+public record GetToolByIdQuery(int Id) : IRequest<ToolDetail?>;
+
+public sealed class GetToolByIdHandler : IRequestHandler<GetToolByIdQuery, ToolDetail?>
+{
+    private readonly IToolRepository _toolRepo;
+
+    public GetToolByIdHandler(IToolRepository toolRepo)
+    {
+        _toolRepo = toolRepo;
+    }
+
+    public async Task<ToolDetail?> Handle(GetToolByIdQuery request, CancellationToken ct)
+    {
+        var tool = await _toolRepo.GetByIdAsync(new ToolId(request.Id), ct);
+        if (tool is null) return null;
+
+        var scarcity = tool.ScarcityByLocation.Select(kvp => new ScarcityDto(
+            kvp.Key.Value,
+            LocationName((int)kvp.Key.Value),
+            (int)kvp.Value,
+            ScarcityLevelName((int)kvp.Value))).ToList();
+
+        return new ToolDetail(
+            tool.Id.Value,
+            tool.Model,
+            tool.Description,
+            tool.Manufacturer.Id.Value,
+            tool.Manufacturer.Name,
+            (int)tool.Type,
+            ToolStats.GetTypeName((int)tool.Type),
+            (int)tool.AmortizationRate,
+            AmortizationRateName((int)tool.AmortizationRate),
+            tool.Metadata,
+            scarcity);
+    }
+
+    private static string AmortizationRateName(int rate) => rate switch
+    {
+        1 => "Low", 2 => "Medium", 3 => "High", _ => "Unknown"
+    };
+
+    private static string ScarcityLevelName(int level) => level switch
+    {
+        1 => "Low", 2 => "Medium", 3 => "High", 4 => "Critical", _ => "Unknown"
+    };
+
+    private static string LocationName(int locationId) => locationId switch
+    {
+        1 => "Downtown Workshop",
+        2 => "North Side Branch",
+        3 => "East End Hub",
+        4 => "Westside Station",
+        5 => "Central Warehouse",
+        _ => $"Location {locationId}"
+    };
+}

--- a/src/TSQR.ToolLibrary.WebApi/Queries/GetToolStatsQuery.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Queries/GetToolStatsQuery.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using TSQR.ToolLibrary.Domain;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+
+namespace TSQR.ToolLibrary.WebApi.Queries;
+
+public record GetToolStatsQuery : IRequest<ToolStatsResult>;
+
+public record ToolStatsResult(List<ToolStatsItem> ByType, List<ToolStatsItem> ByScarcity);
+
+public sealed class GetToolStatsHandler : IRequestHandler<GetToolStatsQuery, ToolStatsResult>
+{
+    private readonly IToolRepository _toolRepo;
+
+    public GetToolStatsHandler(IToolRepository toolRepo)
+    {
+        _toolRepo = toolRepo;
+    }
+
+    public async Task<ToolStatsResult> Handle(GetToolStatsQuery request, CancellationToken ct)
+    {
+        var stats = await _toolRepo.GetStatsAsync(ct);
+
+        return new ToolStatsResult(
+            stats.ByType.Select(s => new ToolStatsItem(s.Key, s.Label, s.Count)).ToList(),
+            stats.ByScarcity.Select(s => new ToolStatsItem(s.Key, s.Label, s.Count)).ToList());
+    }
+}

--- a/src/TSQR.ToolLibrary.WebApi/Queries/GetToolsQuery.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Queries/GetToolsQuery.cs
@@ -1,0 +1,66 @@
+using MediatR;
+using TSQR.ToolLibrary.Domain;
+using TSQR.ToolLibrary.Domain.Aggregates.ToolAggregate;
+using TSQR.ToolLibrary.WebApi.Controllers.Dtos;
+
+namespace TSQR.ToolLibrary.WebApi.Queries;
+
+public record GetToolsQuery(string? Q, int? Type, int? ManufacturerId, int Page, int PageSize)
+    : IRequest<PagedResult<ToolListItem>>;
+
+public sealed class GetToolsHandler : IRequestHandler<GetToolsQuery, PagedResult<ToolListItem>>
+{
+    private readonly IToolRepository _toolRepo;
+    private readonly IManufacturerRepository _manufacturerRepo;
+
+    public GetToolsHandler(IToolRepository toolRepo, IManufacturerRepository manufacturerRepo)
+    {
+        _toolRepo = toolRepo;
+        _manufacturerRepo = manufacturerRepo;
+    }
+
+    public async Task<PagedResult<ToolListItem>> Handle(GetToolsQuery request, CancellationToken ct)
+    {
+        var allTools = await _toolRepo.GetAllAsync(ct);
+
+        var filtered = allTools.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(request.Q))
+        {
+            var q = request.Q.ToLowerInvariant();
+            filtered = filtered.Where(t =>
+                t.Model.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+                t.Description.Contains(q, StringComparison.OrdinalIgnoreCase));
+        }
+        if (request.Type.HasValue)
+            filtered = filtered.Where(t => (int)t.Type == request.Type.Value);
+        if (request.ManufacturerId.HasValue)
+            filtered = filtered.Where(t => t.Manufacturer.Id.Value == request.ManufacturerId.Value);
+
+        var list = filtered.ToList();
+        var totalCount = list.Count;
+
+        var paged = list
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToList();
+
+        var items = paged.Select(t => new ToolListItem(
+            t.Id.Value,
+            t.Model,
+            t.Description,
+            (int)t.Type,
+            ToolStats.GetTypeName((int)t.Type),
+            (int)t.AmortizationRate,
+            AmortizationRateName((int)t.AmortizationRate),
+            t.Manufacturer.Id.Value,
+            t.Manufacturer.Name)).ToList();
+
+        return new PagedResult<ToolListItem>(items, totalCount, request.Page, request.PageSize);
+    }
+
+    private static string AmortizationRateName(int rate) => rate switch
+    {
+        1 => "Low", 2 => "Medium", 3 => "High", _ => "Unknown"
+    };
+}

--- a/src/TSQR.ToolLibrary.WebApi/appsettings.json
+++ b/src/TSQR.ToolLibrary.WebApi/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=TSQR_ToolLibrary;Trusted_Connection=True;TrustServerCertificate=True;"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=tsqr_tool_library;Username=postgres;Password=postgres"
   }
 }

--- a/src/TSQR.ToolLibrary.WebApi/docker/docker-compose.yml
+++ b/src/TSQR.ToolLibrary.WebApi/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: tsqr-postgres
+    environment:
+      POSTGRES_DB: tsqr_tool_library
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+volumes:
+  pgdata:

--- a/src/TSQR.ToolLibrary.WebApi/docker/init.sql
+++ b/src/TSQR.ToolLibrary.WebApi/docker/init.sql
@@ -1,0 +1,194 @@
+-- TSQR Tool Library - Schema & Seed Data
+
+CREATE TABLE IF NOT EXISTS Manufacturers (
+    Id SERIAL PRIMARY KEY,
+    Name VARCHAR(200) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS Tools (
+    Id SERIAL PRIMARY KEY,
+    Model VARCHAR(200) NOT NULL,
+    Description VARCHAR(1000) NOT NULL,
+    ManufacturerId INTEGER NOT NULL REFERENCES Manufacturers(Id),
+    ToolType INTEGER NOT NULL,
+    AmortizationRate INTEGER NOT NULL,
+    Metadata TEXT
+);
+
+CREATE TABLE IF NOT EXISTS Locations (
+    Id SERIAL PRIMARY KEY,
+    Name VARCHAR(200) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ToolScarcityByLocation (
+    ToolId INTEGER NOT NULL REFERENCES Tools(Id),
+    LocationId INTEGER NOT NULL REFERENCES Locations(Id),
+    ScarcityLevel INTEGER NOT NULL,
+    PRIMARY KEY (ToolId, LocationId)
+);
+
+CREATE TABLE IF NOT EXISTS Members (
+    Id SERIAL PRIMARY KEY,
+    FirstName VARCHAR(100) NOT NULL,
+    MiddleName VARCHAR(100) NOT NULL,
+    LastName VARCHAR(100) NOT NULL,
+    Age INTEGER NOT NULL,
+    Address VARCHAR(500) NOT NULL,
+    Email VARCHAR(200) NOT NULL,
+    PhoneNumber VARCHAR(50) NOT NULL,
+    Status INTEGER NOT NULL,
+    IsVerified BOOLEAN NOT NULL,
+    VerifiedByAdminId INTEGER REFERENCES Members(Id),
+    VerificationDate TIMESTAMP,
+    MembershipType INTEGER,
+    StartDate TIMESTAMP,
+    EndDate TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS InventoryItems (
+    Id SERIAL PRIMARY KEY,
+    ToolId INTEGER NOT NULL REFERENCES Tools(Id),
+    OriginalOwnerId INTEGER NOT NULL REFERENCES Members(Id),
+    InitialAcquisitionDate TIMESTAMP NOT NULL,
+    SerialNumber VARCHAR(200) NOT NULL,
+    Status INTEGER NOT NULL,
+    Condition INTEGER NOT NULL,
+    CurrentHolderId INTEGER REFERENCES Members(Id),
+    LastBorrowedDate TIMESTAMP,
+    ReservationDate TIMESTAMP,
+    ReservationMemberId INTEGER REFERENCES Members(Id),
+    LoanCount INTEGER NOT NULL DEFAULT 0,
+    TotalUsageTimeTicks BIGINT NOT NULL DEFAULT 0,
+    IsUnderRepair BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS Reservations (
+    Id SERIAL PRIMARY KEY,
+    ItemId INTEGER NOT NULL REFERENCES InventoryItems(Id),
+    MemberId INTEGER NOT NULL REFERENCES Members(Id),
+    ReservationDate TIMESTAMP NOT NULL,
+    ExpiryDate TIMESTAMP NOT NULL,
+    Status INTEGER NOT NULL,
+    IsConfirmed BOOLEAN NOT NULL DEFAULT FALSE,
+    QueuePosition INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS MaintenanceRecords (
+    Id SERIAL PRIMARY KEY,
+    ItemId INTEGER NOT NULL REFERENCES InventoryItems(Id),
+    ReportedById INTEGER NOT NULL REFERENCES Members(Id),
+    ReportedDate TIMESTAMP NOT NULL,
+    Description VARCHAR(2000) NOT NULL,
+    Status INTEGER NOT NULL,
+    CompletedById INTEGER REFERENCES Members(Id),
+    CompletedDate TIMESTAMP,
+    ResultingCondition INTEGER
+);
+
+-- Seed: Manufacturers
+INSERT INTO Manufacturers (Name) VALUES
+    ('DeWalt'),
+    ('Makita'),
+    ('Bosch'),
+    ('Stanley'),
+    ('Milwaukee');
+
+-- Seed: Locations
+INSERT INTO Locations (Name) VALUES
+    ('Downtown Workshop'),
+    ('North Side Branch'),
+    ('East End Hub'),
+    ('Westside Station'),
+    ('Central Warehouse');
+
+-- Seed: Tools (ToolType: 1=HandTool,2=PowerTool,3=GardeningTool,4=ConstructionTool,5=SpecialtyTool,6=Other)
+-- (AmortizationRate: 1=Low,2=Medium,3=High)
+INSERT INTO Tools (Model, Description, ManufacturerId, ToolType, AmortizationRate, Metadata) VALUES
+    ('Claw Hammer 16oz', 'Professional rip claw hammer with shock reduction grip', 1, 1, 1, NULL),
+    ('Precision Screwdriver Set', '6-piece set with magnetic tips and ergonomic handle', 4, 1, 1, '{"pieces": 6}'),
+    ('Cordless Drill 20V', '20V MAX cordless drill with 1/2" chuck and 2-speed transmission', 1, 2, 2, '{"voltage": 20, "chuck": "1/2"}'),
+    ('Circular Saw 7-1/4"', '7-1/4 inch circular saw with electric brake and magnesium shoe', 2, 2, 3, '{"bladeSize": "7.25"}'),
+    ('Round Point Shovel', 'Round point shovel with fiberglass handle and step treads', 4, 3, 1, NULL),
+    ('Bow Rake', '14-tine bow rake with steel tines and 54-inch handle', 4, 3, 1, NULL),
+    ('Torpedo Level 9"', '9-inch torpedo level with rare earth magnets', 3, 4, 1, NULL),
+    ('Masonry Trowel', 'Philadelphia pattern brick trowel with hardwood handle', 4, 4, 1, NULL),
+    ('Electric Pressure Washer', '1800 PSI electric pressure washer with onboard soap tank', 5, 5, 3, '{"psi": 1800}'),
+    ('MIG Welder 140', '110V MIG welder with automatic feed and 6 heat settings', 1, 5, 3, '{"voltage": 110}'),
+    ('Concrete Mixer 3.5 cu ft', '3.5 cubic foot portable concrete mixer with steel drum', 3, 5, 3, NULL),
+    ('Coping Saw', 'Adjustable coping saw with 6-1/2 inch depth', 4, 1, 1, NULL),
+    ('Angle Grinder 4-1/2"', '4-1/2 inch angle grinder with paddle switch and AC/DC switch', 2, 2, 2, NULL),
+    ('Hedge Trimmer 22"', '22-inch dual-action hedge trimmer with rotating handle', 3, 3, 2, '{"bladeLength": 22}'),
+    ('Measuring Tape 25ft', '25-foot measuring tape with fractional markings and blade lock', 4, 1, 1, '{"length": 25}'),
+    ('Combination Wrench Set', '10-piece combination wrench set in SAE sizes', 1, 1, 1, '{"pieces": 10}'),
+    ('Orbital Jigsaw', 'Variable-speed orbital jigsaw with tool-less blade change', 3, 2, 2, NULL),
+    ('Paint Sprayer HVLP', 'HVLP paint sprayer with 3 pattern options and adjustable flow', 5, 5, 2, NULL),
+    ('Wheelbarrow 6 cu ft', '6 cubic foot wheelbarrow with pneumatic tire and heavy-duty frame', 4, 3, 1, NULL),
+    ('Portable Generator 5000W', '5000W portable generator with electric start and CO shutoff', 1, 5, 3, '{"watts": 5000}');
+
+-- Seed: ToolScarcityByLocation (ScarcityLevel: 1=Low,2=Medium,3=High,4=Critical)
+INSERT INTO ToolScarcityByLocation (ToolId, LocationId, ScarcityLevel) VALUES
+    (1, 1, 2), (1, 2, 1), (1, 5, 1),
+    (2, 1, 1), (2, 3, 2),
+    (3, 1, 4), (3, 2, 3), (3, 3, 4), (3, 4, 3), (3, 5, 4),
+    (4, 1, 2), (4, 5, 3),
+    (5, 2, 1), (5, 4, 2),
+    (6, 1, 1), (6, 3, 1),
+    (7, 1, 2), (7, 3, 2), (7, 4, 1),
+    (8, 2, 1),
+    (9, 1, 2), (9, 5, 3),
+    (10, 1, 4), (10, 5, 4),
+    (11, 3, 3), (11, 4, 3),
+    (13, 1, 2), (13, 2, 3), (13, 5, 2),
+    (14, 2, 2), (14, 4, 3),
+    (17, 1, 2), (17, 3, 1),
+    (18, 1, 1), (18, 5, 2),
+    (19, 2, 1), (19, 4, 1),
+    (20, 1, 4), (20, 5, 4);
+
+-- Seed: Members (Status: 1=Active,2=Suspended,3=Banned)
+-- (MembershipType: 1=Regular,2=Repairman,3=LocationCoordinator,4=Admin)
+INSERT INTO Members (FirstName, MiddleName, LastName, Age, Address, Email, PhoneNumber, Status, IsVerified, VerifiedByAdminId, VerificationDate, MembershipType, StartDate, EndDate) VALUES
+    ('John', 'Michael', 'Smith', 34, '123 Oak St, Springfield, IL', 'john.smith@email.com', '555-0101', 1, TRUE, NULL, '2024-01-15 09:00:00', 4, '2024-01-15', NULL),
+    ('Jane', 'Marie', 'Doe', 28, '456 Elm St, Springfield, IL', 'jane.doe@email.com', '555-0102', 1, TRUE, 1, '2024-02-01 10:30:00', 1, '2024-02-01', NULL),
+    ('Robert', 'James', 'Johnson', 45, '789 Pine St, Springfield, IL', 'robert.j@email.com', '555-0103', 1, TRUE, 1, '2024-01-20 14:00:00', 2, '2024-01-20', NULL),
+    ('Emily', 'Grace', 'Williams', 31, '321 Maple Ave, Springfield, IL', 'emily.w@email.com', '555-0104', 1, TRUE, 1, '2024-03-05 11:00:00', 1, '2024-03-05', NULL),
+    ('Michael', 'David', 'Brown', 52, '654 Cedar Ln, Springfield, IL', 'mbrown@email.com', '555-0105', 1, TRUE, 1, '2024-01-10 08:00:00', 3, '2024-01-10', NULL),
+    ('Sarah', 'Elizabeth', 'Davis', 26, '987 Birch Rd, Springfield, IL', 'sarah.davis@email.com', '555-0106', 1, FALSE, NULL, NULL, 1, '2024-06-01', '2024-12-01'),
+    ('David', 'Alan', 'Wilson', 39, '147 Walnut Dr, Springfield, IL', 'dwilson@email.com', '555-0107', 2, TRUE, 1, '2024-03-15 09:30:00', 1, '2024-03-15', NULL),
+    ('Lisa', 'Ann', 'Taylor', 41, '258 Spruce Ct, Springfield, IL', 'lisa.taylor@email.com', '555-0108', 1, TRUE, 1, '2024-04-01 13:00:00', 2, '2024-04-01', NULL),
+    ('Kevin', 'Lee', 'Anderson', 33, '369 Ash Blvd, Springfield, IL', 'kevin.a@email.com', '555-0109', 3, TRUE, 1, '2024-02-20 10:00:00', 1, '2024-02-20', NULL),
+    ('Amanda', 'Rose', 'Martinez', 29, '482 Hickory Way, Springfield, IL', 'amanda.m@email.com', '555-0110', 1, FALSE, NULL, NULL, 1, '2024-07-01', NULL);
+
+-- Seed: InventoryItems (Status: 1=Available,2=Reserved,3=Loaned,4=UnderMaintenance,5=Lost)
+-- (Condition: 1=New,2=Good,3=Fair,4=Repaired,5=Poor)
+INSERT INTO InventoryItems (ToolId, OriginalOwnerId, InitialAcquisitionDate, SerialNumber, Status, Condition, CurrentHolderId, LastBorrowedDate, ReservationDate, ReservationMemberId, LoanCount, TotalUsageTimeTicks, IsUnderRepair) VALUES
+    (1, 2, '2024-01-15 09:00:00', 'DW-HAM-001', 3, 2, 2, '2024-11-20 10:00:00', NULL, NULL, 8, 864000000000, FALSE),
+    (3, 2, '2024-01-15 09:00:00', 'DW-DRL-001', 1, 1, NULL, NULL, NULL, NULL, 3, 144000000000, FALSE),
+    (3, 3, '2024-02-01 10:00:00', 'DW-DRL-002', 4, 3, NULL, NULL, NULL, NULL, 5, 432000000000, TRUE),
+    (4, 4, '2024-03-01 11:00:00', 'MK-SAW-001', 3, 2, 4, '2024-12-01 09:00:00', NULL, NULL, 2, 720000000000, FALSE),
+    (5, 5, '2024-01-20 08:00:00', 'ST-SHV-001', 1, 2, NULL, NULL, NULL, NULL, 12, 864000000000, FALSE),
+    (7, 2, '2024-04-01 14:00:00', 'BS-LVL-001', 2, 1, NULL, NULL, '2024-12-15 09:00:00', 6, 0, 0, FALSE),
+    (9, 8, '2024-05-01 09:00:00', 'ML-PW-001', 1, 1, NULL, NULL, NULL, NULL, 0, 0, FALSE),
+    (10, 3, '2024-02-15 10:00:00', 'DW-WLD-001', 4, 2, NULL, NULL, NULL, NULL, 1, 288000000000, TRUE),
+    (13, 4, '2024-06-01 11:00:00', 'MK-GRND-001', 1, 2, NULL, NULL, NULL, NULL, 4, 216000000000, FALSE),
+    (14, 8, '2024-07-01 13:00:00', 'BS-HEDGE-001', 3, 1, 8, '2024-12-05 08:00:00', NULL, NULL, 1, 720000000000, FALSE),
+    (17, 2, '2024-08-01 09:00:00', 'BS-JIG-001', 1, 1, NULL, NULL, NULL, NULL, 0, 0, FALSE),
+    (19, 5, '2024-03-15 08:00:00', 'ST-WB-001', 1, 2, NULL, NULL, NULL, NULL, 10, 0, FALSE),
+    (20, 5, '2024-09-01 10:00:00', 'DW-GEN-001', 1, 1, NULL, NULL, NULL, NULL, 0, 0, FALSE),
+    (2, 10, '2024-10-01 09:00:00', 'ST-SCR-001', 1, 1, NULL, NULL, NULL, NULL, 0, 0, FALSE),
+    (6, 10, '2024-10-01 09:00:00', 'ST-RAKE-001', 1, 1, NULL, NULL, NULL, NULL, 0, 0, FALSE);
+
+-- Seed: Reservations (Status: 1=Pending,2=Confirmed,3=Active,4=Cancelled,5=Completed)
+INSERT INTO Reservations (ItemId, MemberId, ReservationDate, ExpiryDate, Status, IsConfirmed, QueuePosition) VALUES
+    (6, 6, '2024-12-10 09:00:00', '2024-12-20 09:00:00', 1, FALSE, 0),
+    (6, 10, '2024-12-11 14:00:00', '2024-12-21 14:00:00', 1, FALSE, 1),
+    (2, 4, '2024-12-12 10:00:00', '2024-12-22 10:00:00', 1, FALSE, 0),
+    (7, 2, '2024-12-08 11:00:00', '2024-12-18 11:00:00', 5, TRUE, 0),
+    (13, 6, '2024-12-09 08:00:00', '2024-12-19 08:00:00', 4, FALSE, 0),
+    (9, 8, '2024-12-11 15:00:00', '2024-12-25 15:00:00', 1, FALSE, 0);
+
+-- Seed: MaintenanceRecords (Status: 1=Reported,2=InProgress,3=Completed)
+INSERT INTO MaintenanceRecords (ItemId, ReportedById, ReportedDate, Description, Status, CompletedById, CompletedDate, ResultingCondition) VALUES
+    (3, 3, '2024-12-01 09:00:00', 'Chuck is slipping under load, needs replacement', 2, 8, NULL, NULL),
+    (8, 3, '2024-12-05 10:00:00', 'Wire feed mechanism jams occasionally, needs cleaning and adjustment', 1, NULL, NULL, NULL),
+    (1, 2, '2024-11-10 14:00:00', 'Handle cracked after heavy use, replaced handle and rebalanced', 3, 3, '2024-11-20 16:00:00', 4);


### PR DESCRIPTION
Backend changes for UI support:
- Switch from SqlClient → Npgsql
- Add docker-compose + init.sql with mock data
- IToolRepository, IManufacturerRepository, IDashboardQueries
- ToolRepository, ManufacturerRepository, DashboardQueries implementations
- 3 controllers + 5 MediatR query handlers
- Merge main and fix Result<T> conflict in MaintenanceRecordMapping