### PR TITLE
feat: add JWT Bearer authentication to WebApi

### DIFF
--- a/src/TSQR.ToolLibrary.WebApi/Program.cs
+++ b/src/TSQR.ToolLibrary.WebApi/Program.cs
@@ -1,4 +1,7 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 using TSQR.ToolLibrary.Application;
 using TSQR.ToolLibrary.Domain.Aggregates.InventoryAggregate;
 using TSQR.ToolLibrary.Domain.Aggregates.MaintenanceAggregate;
@@ -17,6 +20,30 @@ TypeHandlerRegistrations.EnsureRegistered();
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
+
+var jwtSection = builder.Configuration.GetSection("Jwt");
+var jwtKey = jwtSection["Key"] ?? throw new InvalidOperationException("JWT Key not configured.");
+var jwtIssuer = jwtSection["Issuer"] ?? "tsqr-identity";
+var jwtAudience = jwtSection["Audience"] ?? "tsqr-services";
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwtIssuer,
+            ValidAudience = jwtAudience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+
+builder.Services.AddAuthorization();
+
 builder.Services.AddControllers()
     .ConfigureApiBehaviorOptions(options =>
     {
@@ -68,6 +95,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 
 app.Run();

--- a/src/TSQR.ToolLibrary.WebApi/TSQR.ToolLibrary.WebApi.csproj
+++ b/src/TSQR.ToolLibrary.WebApi/TSQR.ToolLibrary.WebApi.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="13.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
   </ItemGroup>
 

--- a/src/TSQR.ToolLibrary.WebApi/appsettings.json
+++ b/src/TSQR.ToolLibrary.WebApi/appsettings.json
@@ -6,6 +6,12 @@
     }
   },
   "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "ThisIsASecretKeyForTsqrIdentity_MustBeAtLeast32CharactersLong!",
+    "Issuer": "tsqr-identity",
+    "Audience": "tsqr-services",
+    "AccessTokenExpirationMinutes": 15
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=tsqr_tool_library;Username=postgres;Password=postgres"
   }


### PR DESCRIPTION
Add JWT token validation to tsqr-tool-lib so that the gateway can forward authenticated requests.

- Added Microsoft.AspNetCore.Authentication.JwtBearer v9.0.9
- Configured JWT validation with same key/issuer/audience as tsqr-identity
- Added UseAuthentication/UseAuthorization middleware pipeline
- Added Jwt section to appsettings.json